### PR TITLE
Make it work on windows, and some updates

### DIFF
--- a/launch.json
+++ b/launch.json
@@ -29,6 +29,9 @@
                 "uri": "{{input}}",
                 "target": "_blank"
             }
+        },
+        {
+            "method": "process.wait"
         }
     ]
 }

--- a/launch.json
+++ b/launch.json
@@ -1,0 +1,34 @@
+{
+    "run": [
+        {
+            "method": "shell.start"
+        },
+        {
+            "method": "shell.enter",
+            "params": {
+                "message": "{{self.config.activate_command}}",
+                "on": [{
+                    "event": null,
+                    "return": true
+                }]
+            }
+        },
+        {
+            "method": "shell.enter",
+            "params": {
+                "message": "python -m langflow",
+                "on": [{
+                    "event": "/Access (http[0-9\/.:]+)/",
+                    "return": "{{event.matches[0][1]}}"
+                }]
+            }
+        },
+        {
+            "method": "browser.open",
+            "params": {
+                "uri": "{{input}}",
+                "target": "_blank"
+            }
+        }
+    ]
+}

--- a/pinokio.js
+++ b/pinokio.js
@@ -1,7 +1,11 @@
 module.exports = {
   menu: [
     {
-      html: "<i class='fa-solid fa-play'></i> Start",
+      html: "<i class='fa-solid fa-play'></i> Launch",
+      href: "launch.json",
+    },
+    {
+      html: "<i class='fa-solid fa-gear'></i> Install",
       href: "start.json",
     },
   ],

--- a/pinokio.js
+++ b/pinokio.js
@@ -1,12 +1,12 @@
 module.exports = {
   menu: [
     {
-      html: "<i class='fa-solid fa-play'></i> Launch",
-      href: "launch.json",
-    },
-    {
       html: "<i class='fa-solid fa-gear'></i> Install",
       href: "start.json",
+    },
+    {
+      html: "<i class='fa-solid fa-play'></i> Launch",
+      href: "launch.json",
     },
   ],
 };

--- a/start.json
+++ b/start.json
@@ -31,21 +31,33 @@
             "method": "shell.start"
         },
         {
-            "method": "shell.run",
+            "method": "shell.enter",
             "params": {
-                "message": "{{local.create_venv}}"
+                "message": "{{local.create_venv}}",
+                "on": [{
+                    "event": null,
+                    "return": true
+                }]
+            }
+        },
+        {
+            "method": "shell.enter",
+            "params": {
+                "message": "{{local.activate_command}}",
+                "on": [{
+                    "event": null,
+                    "return": true
+                }]
             }
         },
         {
             "method": "shell.run",
             "params": {
-                "message": "{{local.activate_command}}"
-            }
-        },
-        {
-            "method": "shell.run",
-            "params": {
-                "message": "python -m pip install langflow -U && python -m langflow"
+                "message": "python -m pip install langflow -U && python -m langflow",
+                "on": [{
+                    "event": null,
+                    "return": true
+                }]
             }
         },
         {

--- a/start.json
+++ b/start.json
@@ -9,22 +9,24 @@
                         "key": "create_venv",
                         "title": "Create virtualenv",
                         "description": "Command to create virtualenv",
-                        "default": "python3 -m venv .langflow_venv"
+                        "default": "python -m venv .langflow_venv"
                     },
                     {
                         "key": "activate_command",
                         "title": "Activate virtualenv",
                         "description": "Command to activate virtualenv",
-                        "default": "source .langflow_venv/bin/activate"
+                        "default": "{{os.platform() === 'win32' ? '.langflow_venv\\\\Scripts\\\\activate' : 'source .langflow_venv/bin/activate'}}"
                     }
                 ]
             }
         },
         {
-            "method": "local.set",
+            "method": "self.set",
             "params": {
-                "create_venv": "{{input.create_venv}}",
-                "activate_command": "{{input.activate_command}}"
+                "config.json": {
+                  "create_venv": "{{input.create_venv}}",
+                  "activate_command": "{{input.activate_command}}"
+                }
             }
         },
         {
@@ -33,7 +35,7 @@
         {
             "method": "shell.enter",
             "params": {
-                "message": "{{local.create_venv}}",
+                "message": "{{self.config.create_venv}}",
                 "on": [{
                     "event": null,
                     "return": true
@@ -43,7 +45,7 @@
         {
             "method": "shell.enter",
             "params": {
-                "message": "{{local.activate_command}}",
+                "message": "{{self.config.activate_command}}",
                 "on": [{
                     "event": null,
                     "return": true
@@ -51,19 +53,29 @@
             }
         },
         {
-            "method": "shell.run",
+            "method": "shell.enter",
             "params": {
-                "message": "python -m pip install langflow -U && python -m langflow",
+                "message": "python -m pip install langflow -U",
                 "on": [{
-                    "event": null,
-                    "return": true
+                  "event": null,
+                  "return": true
+                }]
+            }
+        },
+        {
+            "method": "shell.enter",
+            "params": {
+                "message": "python -m langflow",
+                "on": [{
+                    "event": "/Access (http[0-9\/.:]+)/",
+                    "return": "{{event.matches[0][1]}}"
                 }]
             }
         },
         {
             "method": "browser.open",
             "params": {
-                "uri": "http://localhost:7860",
+                "uri": "{{input}}",
                 "target": "_blank"
             }
         }

--- a/start.json
+++ b/start.json
@@ -78,6 +78,9 @@
                 "uri": "{{input}}",
                 "target": "_blank"
             }
+        },
+        {
+            "method": "process.wait"
         }
     ]
 }


### PR DESCRIPTION
There are some quirks across windows and the rest, such as path handling, etc. I've reflected those quirks in the update.

Feel free to take a look at each individual commit, but here's the full summary:

# use "enter" instead of "run" when using "start"

1. "run" creates its own shell so it does not utilize the shell just created by the "shell.start" right above.
2. "shell.enter" does NOT return automatically and only returns when one of the events match. In this case I've added an event handler for the next terminal prompt "event": null, (which indicates that the command has finished and now the terminal is displaying a prompt)

# Windows handling

1. source does not work on windows, and on windows you need to directly execute the command without the source prefix
2. On windows the path uses backslash instead of slash

# Added a launch script

Not enough to be able to just install, because the user needs to be able to launch it again later on. Of course, you could let the user run the whole install script whenever they launch but that's overkill, so separated out a "launch.json" script that only takes care of the launching part.

1. By separating out the launch script from install script, you can automatically start langflow when Pinokio starts. Updated pinokio.js to set the "start" script. This will execute the "launch.json" when Pinokio starts
2. To make this possible, we need the launch.json script to access the activate_command set from the install script (start.json). So instead of using the local variable, use the "self" variable which persists data to JSON files in the same repository. In this case we are persisting the attributes to "config.json" from "start.json", and then later accessing them using "self.config" variable from everywhere (these are automatically imported in all template expressions regardless of which file)

python: use python instead of python3 (on the latest standalone python3 binary on windows, the python binary is named python instead of python3, assuming everything is python)

# After starting the server need to go into standby mode

Everything started by pinokio script gets shut down and garbage collected once the script finishes executing.

This means if you started a server using the script, it will be shut down when the script finishes running.

To avoid this, all you need to do is make sure the script never finishes. You can do this with "process.wait", which effectively keeps the script on a standby mode.
